### PR TITLE
Added Debug Plugin

### DIFF
--- a/game/src/debug.rs
+++ b/game/src/debug.rs
@@ -1,0 +1,1 @@
+pub mod debug_plugin;

--- a/game/src/debug/debug_plugin.rs
+++ b/game/src/debug/debug_plugin.rs
@@ -1,15 +1,18 @@
 use bevy::prelude::*;
 
+///This plugin provides terminal debug capabilities
+///By adding systems, requested information will be printed to the terminal
 pub struct DebugPlugin;
 
-//add the system(s) you wish to use to see debug info
+///add the system(s) you wish to use to have debug info printed to terminal
 impl Plugin for DebugPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, print_test);
+        app.add_systems(Startup, print_debug_active_message);
     }
 }
 
-//Function to test if debugger is added correctly
-fn print_test() {
-    info!("The debugger is working!");
+///Function that verifies that the debugger is active by printing a single message to the terminal on startup
+///To use, add system using add_systems
+fn print_debug_active_message() {
+    info!("The debugger is active!");
 }

--- a/game/src/debug/debug_plugin.rs
+++ b/game/src/debug/debug_plugin.rs
@@ -1,0 +1,15 @@
+use bevy::prelude::*;
+
+pub struct DebugPlugin;
+
+//add the system(s) you wish to use to see debug info
+impl Plugin for DebugPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, print_test);
+    }
+}
+
+//Function to test if debugger is added correctly
+fn print_test() {
+    info!("The debugger is working!");
+}

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -1,8 +1,10 @@
+mod debug;
 mod movement;
 
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
+use debug::debug_plugin::DebugPlugin;
 use movement::plugin::CharacterControllerPlugin;
 
 fn main() {
@@ -11,5 +13,8 @@ fn main() {
         .add_plugins(PhysicsPlugins::default())
         .add_plugins(LdtkPlugin)
         .add_plugins(CharacterControllerPlugin)
+        //user plugins
+        //debug plugin
+        .add_plugins(DebugPlugin)
         .run();
 }

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -14,7 +14,6 @@ fn main() {
         .add_plugins(LdtkPlugin)
         .add_plugins(CharacterControllerPlugin)
         //user plugins
-        //debug plugin
         .add_plugins(DebugPlugin)
         .run();
 }


### PR DESCRIPTION
Created a baseline debug plugin that can be used for printing debug info to the command line. Systems can be added to the plugin as needed and debug can be disabled by removing the plugin in main. Tested using system that printed message to terminal every frame

[//]: # (Please delete any unused sections before submitting)

# Objective
- A baseline debugging plugin was needed to provide debugging functionality using the terminal.
- Fixes #6 

## Solution
Implemented DebugPlugin component.

## New components
DebugPlugin was created

## New systems
added print_test system to DebugPlugin component to provide baseline known good function for testing purposes

## Testing
Tested by running app and verified that the correct message was printed to the terminal every frame

