### PR TITLE
feat: add health and damage system

### DIFF
--- a/game/src/components.rs
+++ b/game/src/components.rs
@@ -1,0 +1,3 @@
+pub mod damage;
+pub mod heal;
+pub mod health;

--- a/game/src/components/damage.rs
+++ b/game/src/components/damage.rs
@@ -1,0 +1,31 @@
+use bevy::prelude::*;
+
+///Pointer component to mark entities that need a Damage calculation
+#[derive(Component, Debug)]
+pub struct Damage {
+    pub value: u32,
+}
+
+impl Damage {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
+}
+
+///Component to represent how much damage an entity does
+#[derive(Component, Debug)]
+pub struct DamageFactor {
+    pub value: u32,
+}
+
+impl DamageFactor {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
+}
+
+///Bundle for all Damage related components
+#[derive(Bundle, Debug)]
+pub struct DamageBundle {
+    pub damage_factor: DamageFactor,
+}

--- a/game/src/components/heal.rs
+++ b/game/src/components/heal.rs
@@ -1,0 +1,31 @@
+use bevy::prelude::*;
+
+///Pointer struct to mark components that need a Heal calculation
+#[derive(Component, Debug)]
+pub struct Heal {
+    pub value: u32,
+}
+
+impl Heal {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
+}
+
+///Component that represents the healing factor
+#[derive(Component, Debug)]
+pub struct HealFactor {
+    pub value: u32,
+}
+
+impl HealFactor {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
+}
+
+///Bundle for all Heal related components
+#[derive(Bundle, Debug)]
+pub struct HealBundle {
+    pub heal_factor: HealFactor,
+}

--- a/game/src/components/health.rs
+++ b/game/src/components/health.rs
@@ -1,0 +1,41 @@
+use bevy::prelude::*;
+
+///pointer struct to mark entity as alive
+#[derive(Component, Debug)]
+pub struct Alive;
+
+///pointer struct to mark entity as dead
+#[derive(Component, Debug)]
+pub struct Dead;
+
+///Health component to track entity health
+#[derive(Component, Debug)]
+pub struct Health {
+    pub maximum: u32,
+    pub current: u32,
+}
+
+impl Health {
+    pub fn new(maximum: u32) -> Self {
+        Self {
+            maximum,
+            current: maximum,
+        }
+    }
+
+    pub fn with_current_health(mut self, health: u32) -> Self {
+        if health >= self.maximum {
+            self.current = self.maximum;
+            self
+        } else {
+            self.current = health;
+            self
+        }
+    }
+}
+
+///HealthBundle to bundle all Health related components
+#[derive(Bundle, Debug)]
+pub struct HealthBundle {
+    pub health: Health,
+}

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -1,11 +1,15 @@
+#[allow(dead_code)]
+mod components;
 mod debug;
 mod movement;
+mod plugins;
 
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 use debug::debug_plugin::DebugPlugin;
 use movement::plugin::CharacterControllerPlugin;
+use plugins::health_and_damage_plugin::HealthAndDamagePlugin;
 
 fn main() {
     App::new()
@@ -14,6 +18,7 @@ fn main() {
         .add_plugins(LdtkPlugin)
         .add_plugins(CharacterControllerPlugin)
         //user plugins
+        .add_plugins(HealthAndDamagePlugin)
         .add_plugins(DebugPlugin)
         .run();
 }

--- a/game/src/plugins.rs
+++ b/game/src/plugins.rs
@@ -1,0 +1,1 @@
+pub mod health_and_damage_plugin;

--- a/game/src/plugins/health_and_damage_plugin.rs
+++ b/game/src/plugins/health_and_damage_plugin.rs
@@ -1,0 +1,47 @@
+use bevy::prelude::*;
+
+use crate::components::{
+    damage::Damage,
+    heal::Heal,
+    health::{Alive, Dead, Health},
+};
+
+///Plugin for calculating and applying damage
+pub struct HealthAndDamagePlugin;
+
+impl Plugin for HealthAndDamagePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, (apply_heal, apply_damage).chain());
+    }
+}
+
+///apply_damage queries for all entities that need a Damage calculation then performs and applies that calculation
+fn apply_damage(
+    mut command: Commands,
+    mut query: Query<(Entity, &mut Health, &Damage), With<Alive>>,
+) {
+    for (entity, mut hp, damage) in query.iter_mut() {
+        if damage.value >= hp.current {
+            command.entity(entity).remove::<Alive>();
+            command.entity(entity).insert(Dead);
+            hp.current = 0;
+        } else {
+            hp.current -= damage.value;
+        }
+
+        command.entity(entity).remove::<Damage>();
+    }
+}
+
+///apply_damage queries for all entities that need a Heal calculation then performs and applies that calculation
+fn apply_heal(mut command: Commands, mut query: Query<(Entity, &mut Health, &Heal), With<Alive>>) {
+    for (entity, mut hp, heal) in query.iter_mut() {
+        if heal.value >= (hp.maximum - hp.current) {
+            hp.current = hp.maximum;
+        } else {
+            hp.current += heal.value;
+        }
+
+        command.entity(entity).remove::<Heal>();
+    }
+}


### PR DESCRIPTION
Add health and damage system under HealthAndDamagePlugin. Entities with a Health component can take damage via entities with a DamageApplied component and can replenish health via entities with HealApplied component

[//]: # (Please delete any unused sections before submitting)

# Objective
Fixes #1 
To implement a health and damage system that gives entities health, enables the removal of HP from entities, and can query for `Dead' entities 

## Solution
- Created a Health component that tracks an entities maximum and current HP. 
- To enable damage, I created a Damage component that can be added to an entity to determine how much damage is to be applied. I also created a DamageApplied component that represents how much damage an entity does. 
- The same pattern is applied for healing (Heal and HealApplied components). 
- The HealthAndDamage plugin queries for entities that have Heal or Damage components then performs the appropriate calculation.
- When an entities current health reaches 0, the Dead tag is applied.

## New components
- Alive/Dead Components: Pointer components that represent an entities status
- Health Component: Component representing entity health that is comprised of the entities max and current health
- HealthBundle Bundle: Bundle for all health related components. Added to allow for future additions of features
- Damage Component: Component that holds the value for how much damage to apply to an entity
- DammageApplied Component: Component that represents how much damage an entity does
- DamageBundle Bundle: Bundle for Damage related Components. Added to allow for future addition of features
- Heal Component: Component that holds the value for how much health to heal
- HealApplied Component: Component that represents how much health an entity can replenish
- HealBundle Bundle: Bundle of Heal related components. Added to allow for future addition of features

## New systems
- HealthAndDamage plugin: Queries for entities with a Heal or Damage tag, performs the calculation, applies the result to the entities, and removes the appropriate tag.

## Testing
- Tested using the debug plugin
- Spawned an entity with 90/100 health, entity that causes 5 damage, entity that causes 2 damage, entity that replenishes 6 health, entity that replenishes 5 health, and an entity that has 0/100 health and is marked as Dead.
- Verified that the Alive entities health changes as expected and stops printing once marked as Dead

